### PR TITLE
1.update csr spfCtrl[33:18] default value to 0x5e7

### DIFF
--- a/src/main/scala/xiangshan/backend/execute/fu/csr/CSR.scala
+++ b/src/main/scala/xiangshan/backend/execute/fu/csr/CSR.scala
@@ -406,7 +406,7 @@ class CSR(implicit p: Parameters) extends FUWithRedirect
     // 4.spfctl[33:18] == [0x0004-0x1111] -> resevered
   // turn off L2 BOP, turn on L1 SMS by default
   val spfctl = RegInit(UInt(XLEN.W), Seq(
-    0 << 18,    // L2 hybridPf default config init: 0
+    0x5e7 << 18,    // L2 hybridPf default config init: 0
     0 << 17,    // L2 pf store only [17] init: false
     1 << 16,    // L1D pf enable stride [16] init: true
     30 << 10,   // L1D active page stride [15:10] init: 30


### PR DESCRIPTION
更新l2 csr 默认值
1.默认开启sms,bop,spp预取
2.过滤默认过滤sms,spp
3.spp 默认开启nextline,bp recovery, shareBO,slow LookUp,默认关闭hint2llc
  // --------------------------------------------------------------------------------
  // csr pf ctrl
  // --------------------------------------------------------------------------------
  // ctrl[15,14,13,12,11,10,9,8,  7, 6, 5, 4, 3,  2, 1, 0]
  //                    |     |   |           |  |      |
  //                    ------    ------------   ------
  //                      |            |           |
  //                  FTConfig    sppConfig     ctrlSwitch
  // default 0000_0101_1110_0111
  // hex:    0    5    e    7
  // default value: 0x05e7
  //switchConfig[0,1,2]
    //| ctrl[0] -> enable sms
    //| ctrl[1] -> enable bop
    //| ctrl[2] -> enable spp
  //sppConfig[3,4,5,6,7]
    //| sppConfig[0] -> enable hint2llc   
    //| sppConfig[1] -> enable Nextline Agreesive
    //| sppConfig[2] -> enable bp recovery
    //| sppConfig[3] -> enable shareBO
    //| sppConfig[4] -> enable slowLookUp
  // filterTableConfig[8,9,10]
    //| fTConfig[0]  -> enable fitter sms
    //| fTConfig[1]  -> enable filter bop
    //| fTConfig[2]  -> enable fitter spp